### PR TITLE
only create random admin username and password if needed

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,14 +16,14 @@ locals {
 }
 
 resource "random_string" "mq_admin_user" {
-  count   = local.enabled && ! local.mq_admin_user_is_set ? 1 : 0
+  count   = local.enabled && local.mq_admin_user_enabled && ! local.mq_admin_user_is_set ? 1 : 0
   length  = 8
   special = false
   number  = false
 }
 
 resource "random_password" "mq_admin_password" {
-  count   = local.enabled && ! local.mq_admin_password_is_set ? 1 : 0
+  count   = local.enabled && local.mq_admin_user_enabled && ! local.mq_admin_password_is_set ? 1 : 0
   length  = 16
   special = false
 }


### PR DESCRIPTION
## what
* only create random strings for admin user and admin password, if we are actually going to use them

## why
* the admin user is a dynamic property and it does NOT get created if admin user is not enabled
* we do not need to create these random strings when the dynamic block does not created
* because the admin use is a dynamic block, we do NOT need to worry about these bing required fields, they are not

## references
* follow up for https://github.com/cloudposse/terraform-aws-mq-broker/commit/867068d24ba43fd583c3d06ad69c84720204c84d

